### PR TITLE
Dark mode color scheme (#21)

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -2,6 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,12 +1,183 @@
 :root {
+  --bg-primary: #ffffff;
+  --bg-secondary: #f8f9fa;
+  --surface: #ffffff57;
+  --surface-hover: #ffffffa0;
+  --surface-elevated: #ffffff;
+  --surface-card: #ffffff;
+
+  --text-primary: #000000;
+  --text-secondary: #3b3b3b;
+  --text-tertiary: #555555;
+  --text-muted: #888888;
   --text-link: #2680c1;
-  --text-dark: #000000;
-  --text-light: #f3f3f3;
+
+  --border-color: #00000025;
+  --border-color-strong: #00000073;
+  --border-subtle: #e2e8f0;
+
+  --shadow-sm: 0px 2px 6px 3px #c5c5c56a;
+  --shadow-md: 0px 1px 4px 2px #5757576a;
+  --shadow-focus: 0px 0px 6px 4px #65656547;
+  --shadow-lg: 0 4px 20px rgba(0, 0, 0, 0.12);
+
+  --navbar-bg: #ffffff57;
+  --navbar-selected: #c4d4f5;
+  --navbar-text: black;
+  --navbar-selected-text: #3b3b3b;
+
+  --btn-primary-bg: #5e80af;
+  --btn-primary-text: #ffffff;
+  --btn-secondary-bg: #ffffff;
+  --btn-secondary-text: #5e80af;
+  --btn-shadow: 0px 2px 6px 3px #c5c5c56a;
+
+  --input-bg: #ffffff;
+  --input-text: inherit;
+  --input-placeholder: #757575;
+
+  --gradient-start: #9123d1ee;
+  --gradient-end: #5e5ec2cb;
+
+  --heading-shadow: 0px 4px 4px #00000040;
+  --header-text-shadow: 1px 1px 10px #ffffff, 1px 1px 10px #cccccc,
+    1px 1px 10px #ffffff, 1px 1px 20px #ffffff, 1px 1px 20px #ffffff;
+
+  --recommended-border: #00000025;
+  --recommended-border-hover: #00000073;
+
+  --tooltip-bg: #ffffff;
+  --tooltip-border: #e2e8f0;
+  --tooltip-heading: #1a1a2e;
+  --tooltip-label: #7c3aed;
+  --tooltip-text: #4a5568;
+
+  --view-toggle-bg: #f1f5f9;
+  --view-toggle-active-bg: #ffffff;
+  --view-toggle-text: #64748b;
+  --view-toggle-active-text: #1e293b;
+  --view-toggle-hover-text: #334155;
+
+  --graph-bg: #fafbfc;
+  --graph-border: #e2e8f0;
+  --graph-legend-bg: #ffffff;
+  --graph-legend-text: #475569;
+  --graph-node-text: #1e293b;
+  --graph-edge: #cbd5e1;
+  --graph-arrow: #94a3b8;
+
+  --spinner-color: #1c3e6f;
+
+  --scrollbar-thumb: rgb(124, 124, 124);
+  --scrollbar-thumb-hover: rgb(97, 97, 97);
+  --scrollbar-track: #d3d3d3fd;
+
+  --feedback-textarea-bg: #ffffff;
+  --feedback-counter: #888888;
+  --feedback-error: #d32f2f;
+  --feedback-thanks-text: #555555;
+
+  --copy-btn-filter: none;
+
+  --li-hover-bg: #80808028;
+
+  color-scheme: light;
+}
+
+[data-theme="dark"] {
+  --bg-primary: #0a0a0a;
+  --bg-secondary: #111111;
+  --surface: #171717cc;
+  --surface-hover: #262626cc;
+  --surface-elevated: #171717;
+  --surface-card: #171717;
+
+  --text-primary: #eeeeee;
+  --text-secondary: #cacaca;
+  --text-tertiary: #9e9e9e;
+  --text-muted: #707070;
+  --text-link: #60a5fa;
+
+  --border-color: #ffffff18;
+  --border-color-strong: #ffffff40;
+  --border-subtle: #262626;
+
+  --shadow-sm: 0px 2px 8px 2px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0px 1px 6px 2px rgba(0, 0, 0, 0.5);
+  --shadow-focus: 0px 0px 8px 3px rgba(100, 100, 255, 0.15);
+  --shadow-lg: 0 4px 24px rgba(0, 0, 0, 0.5);
+
+  --navbar-bg: #17171799;
+  --navbar-selected: #262626;
+  --navbar-text: #eeeeee;
+  --navbar-selected-text: #ffffff;
+
+  --btn-primary-bg: #4a6fa5;
+  --btn-primary-text: #ffffff;
+  --btn-secondary-bg: #1e1e1e;
+  --btn-secondary-text: #8ab4f8;
+  --btn-shadow: 0px 2px 6px 2px rgba(0, 0, 0, 0.35);
+
+  --input-bg: #171717;
+  --input-text: #eeeeee;
+  --input-placeholder: #707070;
+
+  --gradient-start: #b366e0;
+  --gradient-end: #8888e8;
+
+  --heading-shadow: 0px 4px 8px rgba(0, 0, 0, 0.6);
+  --header-text-shadow: none;
+
+  --recommended-border: #ffffff18;
+  --recommended-border-hover: #ffffff40;
+
+  --tooltip-bg: #1e1e1e;
+  --tooltip-border: #3e3e3e;
+  --tooltip-heading: #eeeeee;
+  --tooltip-label: #a78bfa;
+  --tooltip-text: #cacaca;
+
+  --view-toggle-bg: #171717;
+  --view-toggle-active-bg: #262626;
+  --view-toggle-text: #9e9e9e;
+  --view-toggle-active-text: #eeeeee;
+  --view-toggle-hover-text: #cacaca;
+
+  --graph-bg: #111111;
+  --graph-border: #262626;
+  --graph-legend-bg: #171717;
+  --graph-legend-text: #9e9e9e;
+  --graph-node-text: #eeeeee;
+  --graph-edge: #3e3e3e;
+  --graph-arrow: #585858;
+
+  --spinner-color: #60a5fa;
+
+  --scrollbar-thumb: #3e3e3e;
+  --scrollbar-thumb-hover: #585858;
+  --scrollbar-track: #171717;
+
+  --feedback-textarea-bg: #171717;
+  --feedback-counter: #707070;
+  --feedback-error: #ef5350;
+  --feedback-thanks-text: #9e9e9e;
+
+  --copy-btn-filter: invert(1) brightness(0.85);
+
+  --li-hover-bg: #ffffff12;
+
+  color-scheme: dark;
 }
 
 html {
   scroll-behavior: smooth;
   overflow-x: hidden;
+}
+
+body {
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  transition: background-color 300ms ease, color 300ms ease;
 }
 
 .page {
@@ -67,17 +238,17 @@ html {
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: rgb(97, 97, 97);
+  background: var(--scrollbar-thumb-hover);
 }
 
 ::-webkit-scrollbar-thumb {
-  background-color: rgb(124, 124, 124);
-  background: rgb(124, 124, 124);
+  background-color: var(--scrollbar-thumb);
+  background: var(--scrollbar-thumb);
   border-radius: 3px;
 }
 
 ::-webkit-scrollbar-track {
-  background: #d3d3d3fd;
+  background: var(--scrollbar-track);
   border-radius: 3px;
 }
 
@@ -95,4 +266,5 @@ html {
 
 a {
   text-decoration: none !important;
+  color: var(--text-link);
 }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2,6 +2,7 @@ import { Analytics } from "@vercel/analytics/react";
 import { SnackbarProvider } from "notistack";
 import { BrowserRouter, Route, Routes, useLocation } from "react-router-dom";
 
+import { ThemeProvider } from "./context/ThemeContext";
 import NavBar from "./components/NavBar/NavBar";
 import ScrollToTop from "./components/misc/ScrollToTop/ScrollToTop";
 import "./App.css";
@@ -11,12 +12,14 @@ const appRoutes = [...pages.main, ...pages.hidden];
 
 export default function App() {
   return (
-    <SnackbarProvider>
-      <BrowserRouter>
-        <Analytics />
-        <TransitionRoutes />
-      </BrowserRouter>
-    </SnackbarProvider>
+    <ThemeProvider>
+      <SnackbarProvider>
+        <BrowserRouter>
+          <Analytics />
+          <TransitionRoutes />
+        </BrowserRouter>
+      </SnackbarProvider>
+    </ThemeProvider>
   );
 }
 

--- a/client/src/components/Button/Button.scss
+++ b/client/src/components/Button/Button.scss
@@ -8,9 +8,9 @@
   font-weight: 700;
   margin: 2px;
   cursor: pointer;
-  transition: transform 200ms, background-color 200ms;
+  transition: transform 200ms, background-color 200ms, color 200ms;
   user-select: none;
-  box-shadow: 0px 2px 6px 3px #c5c5c56a;
+  box-shadow: var(--btn-shadow);
   justify-content: center;
   align-items: center;
   vertical-align: middle;
@@ -35,14 +35,14 @@
 
 .primary-button {
   @extend .button;
-  color: white;
-  background-color: #5e80af;
+  color: var(--btn-primary-text);
+  background-color: var(--btn-primary-bg);
 }
 
 .secondary-button {
   @extend .button;
-  background-color: white;
-  color: #5e80af;
+  background-color: var(--btn-secondary-bg);
+  color: var(--btn-secondary-text);
 }
 
 .icon-button {

--- a/client/src/components/NavBar/NavBar.jsx
+++ b/client/src/components/NavBar/NavBar.jsx
@@ -1,5 +1,6 @@
 import { Link, useLocation } from "react-router-dom";
 import { pages } from "../../util/pages";
+import ThemeToggle from "../ThemeToggle/ThemeToggle";
 import "./NavBar.scss";
 
 export default function Navbar() {
@@ -20,6 +21,7 @@ export default function Navbar() {
           </Link>
         );
       })}
+      <ThemeToggle />
     </div>
   );
 }

--- a/client/src/components/NavBar/NavBar.scss
+++ b/client/src/components/NavBar/NavBar.scss
@@ -5,24 +5,25 @@
   display: flex;
   flex-direction: row;
   justify-content: flex-end;
+  align-items: center;
 }
 
 .navbar-link {
   font-size: 18px;
   border-radius: 7px;
-  background-color: #ffffff57;
+  background-color: var(--navbar-bg);
   backdrop-filter: blur(3px);
   padding: 8px 15px;
   margin: 10px 2px 10px 0px;
-  color: black;
+  color: var(--navbar-text);
 
-  transition: transform 300ms, background-color 400ms;
+  transition: transform 300ms, background-color 400ms, color 300ms;
   &:hover {
     transform: scale(1.05);
   }
 }
 .navbar-link-selected {
-  transition: transform 300ms, background-color 400ms;
-  background-color: #c4d4f5;
-  color: #3b3b3b;
+  transition: transform 300ms, background-color 400ms, color 300ms;
+  background-color: var(--navbar-selected);
+  color: var(--navbar-selected-text);
 }

--- a/client/src/components/Searchbar/Searchbar.scss
+++ b/client/src/components/Searchbar/Searchbar.scss
@@ -1,17 +1,19 @@
 .text-input-search {
   font-size: 17px;
-  background-color: white;
+  background-color: var(--input-bg);
+  color: var(--input-text);
   border-radius: 10px;
   margin: 4px 0px;
   padding: 12px 25px;
   width: 100%;
-  box-shadow: 0px 2px 6px 3px #c5c5c56a;
+  box-shadow: var(--shadow-sm);
   outline: none;
   border: none;
-  transition: box-shadow 300ms, padding 300ms;
+  transition: box-shadow 300ms, padding 300ms, background-color 300ms;
 
   &::placeholder {
     transition: opacity 300ms, transform 700ms;
+    color: var(--input-placeholder);
   }
 
   &:focus::placeholder {
@@ -19,13 +21,13 @@
   }
 
   &:hover {
-    box-shadow: 0px 1px 4px 2px #5757576a;
+    box-shadow: var(--shadow-md);
     padding: 12px 30px;
     transition: box-shadow 500ms, padding 500ms;
   }
 
   &:focus {
-    box-shadow: 0px 0px 6px 4px #65656547;
+    box-shadow: var(--shadow-focus);
     padding: 12px 25px;
     transition: box-shadow 500ms, padding 500ms;
   }

--- a/client/src/components/ThemeToggle/ThemeToggle.jsx
+++ b/client/src/components/ThemeToggle/ThemeToggle.jsx
@@ -1,0 +1,42 @@
+import { useTheme } from "../../context/ThemeContext";
+import "./ThemeToggle.scss";
+
+export default function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+  const isDark = theme === "dark";
+
+  return (
+    <button
+      className="theme-toggle"
+      onClick={toggleTheme}
+      aria-label={`Switch to ${isDark ? "light" : "dark"} mode`}
+      title={`Switch to ${isDark ? "light" : "dark"} mode`}
+    >
+      <svg
+        className="theme-toggle-icon"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        {isDark ? (
+          <>
+            <circle cx="12" cy="12" r="5" />
+            <line x1="12" y1="1" x2="12" y2="3" />
+            <line x1="12" y1="21" x2="12" y2="23" />
+            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+            <line x1="1" y1="12" x2="3" y2="12" />
+            <line x1="21" y1="12" x2="23" y2="12" />
+            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+          </>
+        ) : (
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+        )}
+      </svg>
+    </button>
+  );
+}

--- a/client/src/components/ThemeToggle/ThemeToggle.scss
+++ b/client/src/components/ThemeToggle/ThemeToggle.scss
@@ -1,0 +1,31 @@
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 8px;
+  border: none;
+  background-color: var(--surface);
+  backdrop-filter: blur(3px);
+  cursor: pointer;
+  margin: 10px 10px 10px 2px;
+  padding: 0;
+  transition: transform 300ms, background-color 300ms;
+  color: var(--text-primary);
+
+  &:hover {
+    transform: scale(1.1);
+    background-color: var(--surface-hover);
+  }
+
+  &:active {
+    transform: scale(0.95);
+  }
+}
+
+.theme-toggle-icon {
+  width: 20px;
+  height: 20px;
+  transition: transform 400ms ease;
+}

--- a/client/src/context/ThemeContext.jsx
+++ b/client/src/context/ThemeContext.jsx
@@ -1,0 +1,35 @@
+import { createContext, useContext, useEffect, useState } from "react";
+
+const ThemeContext = createContext();
+
+function getInitialTheme() {
+  const stored = localStorage.getItem("theme");
+  if (stored === "dark" || stored === "light") return stored;
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
+export function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState(getInitialTheme);
+
+  useEffect(() => {
+    document.documentElement.setAttribute("data-theme", theme);
+    localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  const toggleTheme = () =>
+    setTheme((prev) => (prev === "dark" ? "light" : "dark"));
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error("useTheme must be used within ThemeProvider");
+  return ctx;
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,8 +1,7 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
+    'Helvetica Neue', Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/client/src/pages/AboutPage/AboutPage.scss
+++ b/client/src/pages/AboutPage/AboutPage.scss
@@ -8,8 +8,9 @@
   h1 {
     font-size: 50px;
     font-weight: 700;
-    text-shadow: 0px 4px 4px #00000040;
+    text-shadow: var(--heading-shadow);
     text-align: center;
+    color: var(--text-primary);
   }
 
   p {
@@ -17,6 +18,7 @@
     font-weight: 400;
     margin-bottom: 5px;
     text-align: center;
+    color: var(--text-secondary);
   }
 
   @media (max-width: 767px) {

--- a/client/src/pages/FeedbackPage/FeedbackPage.scss
+++ b/client/src/pages/FeedbackPage/FeedbackPage.scss
@@ -8,8 +8,9 @@
   h1 {
     font-size: 50px;
     font-weight: 700;
-    text-shadow: 0px 4px 4px #00000040;
+    text-shadow: var(--heading-shadow);
     text-align: center;
+    color: var(--text-primary);
   }
 
   .feedback-subtitle {
@@ -17,6 +18,7 @@
     font-weight: 400;
     text-align: center;
     max-width: 600px;
+    color: var(--text-secondary);
   }
 
   @media (max-width: 767px) {
@@ -40,19 +42,21 @@
 .feedback-textarea {
   font-family: inherit;
   font-size: 17px;
-  background-color: white;
+  background-color: var(--feedback-textarea-bg);
+  color: var(--text-primary);
   border-radius: 10px;
   padding: 16px 25px;
   width: 100%;
-  box-shadow: 0px 2px 6px 3px #c5c5c56a;
+  box-shadow: var(--shadow-sm);
   outline: none;
   border: none;
   resize: vertical;
   min-height: 140px;
-  transition: box-shadow 300ms;
+  transition: box-shadow 300ms, background-color 300ms;
 
   &::placeholder {
     transition: opacity 300ms;
+    color: var(--input-placeholder);
   }
 
   &:focus::placeholder {
@@ -60,11 +64,11 @@
   }
 
   &:hover {
-    box-shadow: 0px 1px 4px 2px #5757576a;
+    box-shadow: var(--shadow-md);
   }
 
   &:focus {
-    box-shadow: 0px 0px 6px 4px #65656547;
+    box-shadow: var(--shadow-focus);
   }
 
   @media (max-width: 767px) {
@@ -84,13 +88,13 @@
 
 .feedback-counter {
   font-size: 13px;
-  color: #888;
+  color: var(--feedback-counter);
   margin-left: auto;
 }
 
 .feedback-error {
   font-size: 14px;
-  color: #d32f2f;
+  color: var(--feedback-error);
 }
 
 .feedback-thanks {
@@ -101,11 +105,12 @@
     font-size: 36px;
     font-weight: 700;
     margin-bottom: 12px;
+    color: var(--text-primary);
   }
 
   p {
     font-size: 18px;
-    color: #555;
+    color: var(--feedback-thanks-text);
   }
 
   @media (max-width: 767px) {

--- a/client/src/pages/HomePage/HomePage.scss
+++ b/client/src/pages/HomePage/HomePage.scss
@@ -19,18 +19,19 @@
   h1 {
     font-size: 70px;
     font-weight: 700;
-    text-shadow: 0px 4px 4px #00000040;
+    text-shadow: var(--heading-shadow);
+    color: var(--text-primary);
   }
 
   h2 {
     font-size: 24px;
     font-weight: 400;
     margin-bottom: 0px;
+    color: var(--text-secondary);
   }
 
   .header-shadow {
-    text-shadow: 1px 1px 10px #ffffff, 1px 1px 10px #cccccc,
-      1px 1px 10px #ffffff, 1px 1px 20px #ffffff, 1px 1px 20px #ffffff;
+    text-shadow: var(--header-text-shadow);
   }
 
   @media (max-width: 767px) {
@@ -47,7 +48,7 @@
   }
 
   .gradient-text {
-    background-image: linear-gradient(to right, #9123d1ee, #5e5ec2cb);
+    background-image: linear-gradient(to right, var(--gradient-start), var(--gradient-end));
     -webkit-background-clip: text;
     background-clip: text;
     -webkit-text-fill-color: transparent;
@@ -60,6 +61,7 @@
     font-size: 28px;
     margin-top: 25px;
     margin-bottom: 15px;
+    color: var(--text-primary);
     @media (max-width: 767px) {
       margin-top: 35px;
       margin-bottom: 8px;
@@ -69,12 +71,13 @@
 
   .recommended-prompt {
     border-radius: 10px;
-    border-color: #00000025;
+    border-color: var(--recommended-border);
     border-width: 2px;
     padding: 10px 20px;
     border-style: solid;
     margin-bottom: 15px;
     margin-right: 15px;
+    color: var(--text-secondary);
     @media (max-width: 767px) {
       margin: 5px;
       min-width: 200px;
@@ -87,10 +90,10 @@
       font-size: 14px;
     }
     user-select: none;
-    transition: border-color 300ms, opacity 300ms;
+    transition: border-color 300ms, opacity 300ms, color 300ms;
     cursor: pointer;
     &:hover {
-      border-color: #00000073;
+      border-color: var(--recommended-border-hover);
       opacity: 0.8;
     }
   }

--- a/client/src/pages/LearningPath/LearningPath.scss
+++ b/client/src/pages/LearningPath/LearningPath.scss
@@ -7,19 +7,26 @@
     font-weight: 700;
     text-transform: capitalize;
     margin-bottom: 20px;
+    color: var(--text-primary);
   }
 
   h2 {
     font-size: 27px;
     font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  p {
+    color: var(--text-secondary);
   }
 
   li {
     font-size: 20px;
     padding: 0 5px;
+    color: var(--text-primary);
     transition: background-color 500ms;
     &:hover {
-      background-color: #80808028;
+      background-color: var(--li-hover-bg);
       cursor: move;
       border-radius: 5px;
     }
@@ -55,7 +62,7 @@
     position: relative;
     z-index: 0;
     border-radius: 10px;
-    border-color: #00000025;
+    border-color: var(--border-color);
     border-width: 2px;
     padding: 20px 30px;
     border-style: solid;
@@ -89,6 +96,7 @@
     width: 40px;
     height: 40px;
     transition: opacity 500ms;
+    filter: var(--copy-btn-filter);
     &:hover {
       opacity: 0.4;
       cursor: pointer;
@@ -108,11 +116,11 @@
     left: 0;
     top: calc(100% + 4px);
     z-index: 1000;
-    background: #ffffff;
-    border: 1px solid #e2e8f0;
+    background: var(--tooltip-bg);
+    border: 1px solid var(--tooltip-border);
     border-radius: 10px;
     padding: 14px 18px;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.12);
+    box-shadow: var(--shadow-lg);
     min-width: 280px;
     max-width: 360px;
     pointer-events: none;
@@ -125,9 +133,9 @@
       left: 20px;
       width: 10px;
       height: 10px;
-      background: #ffffff;
-      border-top: 1px solid #e2e8f0;
-      border-left: 1px solid #e2e8f0;
+      background: var(--tooltip-bg);
+      border-top: 1px solid var(--tooltip-border);
+      border-left: 1px solid var(--tooltip-border);
       transform: rotate(45deg);
     }
 
@@ -135,7 +143,7 @@
       font-size: 15px;
       font-weight: 700;
       margin: 0 0 10px;
-      color: #1a1a2e;
+      color: var(--tooltip-heading);
     }
 
     .tooltip-section {
@@ -149,7 +157,7 @@
         font-weight: 700;
         text-transform: uppercase;
         letter-spacing: 0.6px;
-        color: #7c3aed;
+        color: var(--tooltip-label);
         display: block;
         margin-bottom: 2px;
       }
@@ -157,7 +165,7 @@
       p {
         font-size: 13px;
         line-height: 1.45;
-        color: #4a5568;
+        color: var(--tooltip-text);
         margin: 0;
       }
     }
@@ -179,7 +187,7 @@
   .view-toggle {
     display: flex;
     gap: 4px;
-    background: #f1f5f9;
+    background: var(--view-toggle-bg);
     border-radius: 10px;
     padding: 4px;
     width: fit-content;
@@ -194,16 +202,16 @@
       cursor: pointer;
       transition: all 200ms;
       background: transparent;
-      color: #64748b;
+      color: var(--view-toggle-text);
 
       &.active {
-        background: #ffffff;
-        color: #1e293b;
+        background: var(--view-toggle-active-bg);
+        color: var(--view-toggle-active-text);
         box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
       }
 
       &:hover:not(.active) {
-        color: #334155;
+        color: var(--view-toggle-hover-text);
       }
     }
   }
@@ -212,9 +220,9 @@
 .network-graph-container {
   position: relative;
   width: 100%;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--graph-border);
   border-radius: 12px;
-  background: #fafbfc;
+  background: var(--graph-bg);
   overflow: hidden;
   animation: fade-in 600ms ease-out;
 
@@ -228,8 +236,8 @@
     display: flex;
     gap: 16px;
     padding: 12px 18px;
-    border-bottom: 1px solid #e2e8f0;
-    background: #ffffff;
+    border-bottom: 1px solid var(--graph-border);
+    background: var(--graph-legend-bg);
 
     .legend-item {
       display: flex;
@@ -237,7 +245,7 @@
       gap: 6px;
       font-size: 13px;
       font-weight: 600;
-      color: #475569;
+      color: var(--graph-legend-text);
     }
 
     .legend-dot {
@@ -249,11 +257,11 @@
 }
 
 .graph-tooltip {
-  background: #ffffff;
-  border: 1px solid #e2e8f0;
+  background: var(--tooltip-bg);
+  border: 1px solid var(--tooltip-border);
   border-radius: 10px;
   padding: 14px 18px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.12);
+  box-shadow: var(--shadow-lg);
   min-width: 240px;
   max-width: 340px;
   animation: fade-in 100ms ease-out;
@@ -262,7 +270,7 @@
     font-size: 15px;
     font-weight: 700;
     margin: 0 0 10px;
-    color: #1a1a2e;
+    color: var(--tooltip-heading);
     display: flex;
     align-items: center;
     gap: 8px;
@@ -270,7 +278,7 @@
 
   .edge-title {
     font-size: 14px;
-    color: #7c3aed;
+    color: var(--tooltip-label);
   }
 
   .level-badge {
@@ -295,7 +303,7 @@
       font-weight: 700;
       text-transform: uppercase;
       letter-spacing: 0.6px;
-      color: #7c3aed;
+      color: var(--tooltip-label);
       display: block;
       margin-bottom: 2px;
     }
@@ -303,7 +311,7 @@
     p {
       font-size: 13px;
       line-height: 1.45;
-      color: #4a5568;
+      color: var(--tooltip-text);
       margin: 0;
     }
   }
@@ -339,6 +347,7 @@
 .bad-request {
   text-align: center;
   margin: 5px 0px;
+  color: var(--text-secondary);
 }
 
 .search-more {
@@ -346,7 +355,7 @@
 }
 
 .gradient-text {
-  background-image: linear-gradient(to right, #9123d1ee, #5e5ec2cb);
+  background-image: linear-gradient(to right, var(--gradient-start), var(--gradient-end));
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;

--- a/client/src/pages/LearningPath/NetworkGraph.jsx
+++ b/client/src/pages/LearningPath/NetworkGraph.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import * as d3 from "d3";
+import { useTheme } from "../../context/ThemeContext";
 
 const LEVEL_COLORS = {
   Beginner: "#22c55e",
@@ -8,9 +9,16 @@ const LEVEL_COLORS = {
 };
 
 const LEVEL_COLORS_LIGHT = {
-  Beginner: "#dcfce7",
-  Intermediate: "#fef3c7",
-  Advanced: "#fee2e2",
+  light: {
+    Beginner: "#dcfce7",
+    Intermediate: "#fef3c7",
+    Advanced: "#fee2e2",
+  },
+  dark: {
+    Beginner: "#14532d",
+    Intermediate: "#713f12",
+    Advanced: "#7f1d1d",
+  },
 };
 
 const NODE_RADIUS = 28;
@@ -38,12 +46,24 @@ function wrapText(text, maxWidth) {
   return lines;
 }
 
+function getThemeColors(theme) {
+  const isDark = theme === "dark";
+  return {
+    nodeFills: LEVEL_COLORS_LIGHT[isDark ? "dark" : "light"],
+    nodeText: isDark ? "#eeeeee" : "#1e293b",
+    edge: isDark ? "#3e3e3e" : "#cbd5e1",
+    arrow: isDark ? "#585858" : "#94a3b8",
+    edgeHighlight: "#7c3aed",
+  };
+}
+
 export default function NetworkGraph({ nodes, edges }) {
   const svgRef = useRef(null);
   const containerRef = useRef(null);
   const simulationRef = useRef(null);
   const [tooltip, setTooltip] = useState(null);
   const [dimensions, setDimensions] = useState({ width: 900, height: 600 });
+  const { theme } = useTheme();
 
   const handleResize = useCallback(() => {
     if (containerRef.current) {
@@ -64,6 +84,7 @@ export default function NetworkGraph({ nodes, edges }) {
   useEffect(() => {
     if (!nodes?.length || !svgRef.current) return;
 
+    const colors = getThemeColors(theme);
     const { width, height } = dimensions;
     const nodeMap = new Map(nodes.map((n) => [n.id, { ...n }]));
     const validEdges = edges.filter((e) => nodeMap.has(e.source) && nodeMap.has(e.target));
@@ -86,7 +107,7 @@ export default function NetworkGraph({ nodes, edges }) {
       .attr("orient", "auto")
       .append("path")
       .attr("d", "M0,0 L10,3 L0,6 Z")
-      .attr("fill", "#94a3b8");
+      .attr("fill", colors.arrow);
 
     const g = svg.append("g");
 
@@ -101,7 +122,7 @@ export default function NetworkGraph({ nodes, edges }) {
       .selectAll("line")
       .data(simEdges)
       .join("line")
-      .attr("stroke", "#cbd5e1")
+      .attr("stroke", colors.edge)
       .attr("stroke-width", 2)
       .attr("marker-end", `url(#${ARROW_ID})`)
       .attr("pointer-events", "none");
@@ -118,7 +139,7 @@ export default function NetworkGraph({ nodes, edges }) {
       .on("mouseenter", (event, d) => {
         const sourceNode = simNodes.find((n) => n.id === (typeof d.source === "object" ? d.source.id : d.source));
         const targetNode = simNodes.find((n) => n.id === (typeof d.target === "object" ? d.target.id : d.target));
-        linkGroup.filter((ld) => ld === d).attr("stroke", "#7c3aed").attr("stroke-width", 3);
+        linkGroup.filter((ld) => ld === d).attr("stroke", colors.edgeHighlight).attr("stroke-width", 3);
         setTooltip({
           type: "edge",
           x: event.clientX,
@@ -134,7 +155,7 @@ export default function NetworkGraph({ nodes, edges }) {
         setTooltip((prev) => (prev ? { ...prev, x: event.clientX, y: event.clientY } : null));
       })
       .on("mouseleave", (event, d) => {
-        linkGroup.filter((ld) => ld === d).attr("stroke", "#cbd5e1").attr("stroke-width", 2);
+        linkGroup.filter((ld) => ld === d).attr("stroke", colors.edge).attr("stroke-width", 2);
         setTooltip(null);
       });
 
@@ -167,7 +188,7 @@ export default function NetworkGraph({ nodes, edges }) {
     nodeGroup
       .append("circle")
       .attr("r", NODE_RADIUS)
-      .attr("fill", (d) => LEVEL_COLORS_LIGHT[d.level] || "#f1f5f9")
+      .attr("fill", (d) => colors.nodeFills[d.level] || "#f1f5f9")
       .attr("stroke", (d) => LEVEL_COLORS[d.level] || "#64748b")
       .attr("stroke-width", 2.5);
 
@@ -182,7 +203,7 @@ export default function NetworkGraph({ nodes, edges }) {
           .attr("dy", `${(i - (lines.length - 1) / 2) * 1.15 + 0.35}em`)
           .attr("font-size", lines.length > 2 ? "8px" : "9px")
           .attr("font-weight", 600)
-          .attr("fill", "#1e293b")
+          .attr("fill", colors.nodeText)
           .attr("pointer-events", "none");
       });
     });
@@ -245,7 +266,7 @@ export default function NetworkGraph({ nodes, edges }) {
     return () => {
       simulation.stop();
     };
-  }, [nodes, edges, dimensions]);
+  }, [nodes, edges, dimensions, theme]);
 
   return (
     <div ref={containerRef} className="network-graph-container">
@@ -270,8 +291,11 @@ export default function NetworkGraph({ nodes, edges }) {
 
 function GraphTooltip({ tooltip }) {
   const { type, x, y, data } = tooltip;
+  const { theme } = useTheme();
   const offsetX = 15;
   const offsetY = 10;
+
+  const fillColors = LEVEL_COLORS_LIGHT[theme === "dark" ? "dark" : "light"];
 
   const style = {
     position: "fixed",
@@ -288,7 +312,7 @@ function GraphTooltip({ tooltip }) {
           <span
             className="level-badge"
             style={{
-              background: LEVEL_COLORS_LIGHT[data.level],
+              background: fillColors[data.level],
               color: LEVEL_COLORS[data.level],
               borderColor: LEVEL_COLORS[data.level],
             }}

--- a/client/src/pages/LoadingSpinner/LoadingSpinner.scss
+++ b/client/src/pages/LoadingSpinner/LoadingSpinner.scss
@@ -8,12 +8,13 @@
     width: 45px;
     height: 45px;
     border-radius: 15px;
-    border: #1c3e6f solid 5px;
+    border: var(--spinner-color) solid 5px;
     animation: spin ease 700ms infinite forwards;
   }
   p {
     text-align: center;
     font-size: 16px;
+    color: var(--text-secondary);
   }
 }
 


### PR DESCRIPTION
## Add dark mode toggle with Claude Code docs-inspired color scheme

- Create ThemeContext with localStorage persistence and system preference detection
- Add ThemeToggle component (sun/moon icon) in NavBar
- Define comprehensive CSS custom properties for light and dark themes in App.css
- Dark theme uses near-black backgrounds (#0a0a0a), dark surfaces (#171717), and light text (#eeeeee) inspired by code.claude.com/docs dark mode
- Update all SCSS files to use CSS variables: NavBar, Button, Searchbar, HomePage, LearningPath, FeedbackPage, AboutPage, LoadingSpinner
- Update NetworkGraph.jsx with theme-aware colors for nodes, edges, and text
- Smooth transitions between themes with 300ms ease



## Replace gradient text with solid accent color and switch font to Inter

- Remove purple-to-blue gradient from topic/counter text (felt vibe-coded)
- Light mode accent: #c2410c (burnt terracotta) — warm, deliberate, readable
- Dark mode accent: #fb923c (bright orange) — vibrant on dark backgrounds
- Rename CSS class from .gradient-text to .accent-text
- Replace --gradient-start/--gradient-end vars with single --accent-color
- Add Inter font via Google Fonts for a cleaner, more modern typography
- Update font stack in index.css to prioritize Inter



## Revert accent color back to gradient text for topic/counter

Restores the purple-to-blue gradient on the counter and learning topic text per user preference. Keeps Inter font and all other dark-mode work.



---------